### PR TITLE
Ride and Eats Icons and navigate to next screen to build out

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,6 @@
 import 'react-native-gesture-handler';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, KeyboardAvoidingView, Platform } from 'react-native';
 import HomeScreen from './screens/HomeScreen';
 import MapScreen from './screens/MapScreen';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -21,8 +21,15 @@ export default function App() {
 
   return (
     <Provider store={ store }>
-      <SafeAreaProvider>
       <NavigationContainer>
+      <SafeAreaProvider>
+
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : "height" }
+        keyboardVerticalOffset={ Platform.OS === "ios" ? -64 : 0} 
+      >
+      
       <Stack.Navigator
       initialRouteName='HomeScreen'
       >
@@ -44,8 +51,10 @@ export default function App() {
          />
 
       </Stack.Navigator>
-      </NavigationContainer>
+
+      </KeyboardAvoidingView>
       </SafeAreaProvider>
+      </NavigationContainer>
     </Provider>
   );
 }

--- a/components/Map.js
+++ b/components/Map.js
@@ -40,7 +40,9 @@ if(destination && origin)console.log(` Destination: ${destination.description}, 
     >
 
     { origin && destination && (
-      <MapViewDirections 
+      <MapViewDirections
+        // style={{ flex: 1 }}
+        // style={{position: "absolute", bottom: 50}}
         origin={ origin.description }
         destination={ destination.description }
         apikey={ GOOGLE_API_KEY }

--- a/components/NavFavorites.js
+++ b/components/NavFavorites.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { Icon } from 'react-native-elements';
 import tw from 'tailwind-react-native-classnames';
 
-
+// Come back here and implement shortcut rides basically just make this functional
 
 const data = [
     {
@@ -26,7 +26,7 @@ const NavFavorites = () => {
         data={data}
         keyExtractor={(item) => item.id }
         ItemSeparatorComponent={(item) => (
-            <View style={[tw`bg-gray-200`, { height: 0.5 }]}/>
+            <View style={[tw`bg-gray-600`, { height: 0.5 }]}/>
         )}
         renderItem={({item: { location, destination, icon } }) => (
             <TouchableOpacity 

--- a/components/NavigateCard.js
+++ b/components/NavigateCard.js
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View, SafeAreaView } from 'react-native'
+import { StyleSheet, Text, View, SafeAreaView, TouchableOpacity } from 'react-native'
 import React from 'react'
 import tw from 'tailwind-react-native-classnames';
 import { GooglePlacesAutocomplete } from 'react-native-google-places-autocomplete';
@@ -6,6 +6,8 @@ import { GOOGLE_API_KEY } from '@env';
 import { useDispatch } from 'react-redux';
 import { setDestination } from '../slices/navSlice';
 import { useNavigation } from '@react-navigation/native';
+import NavFavorites from './NavFavorites';
+import { Icon } from 'react-native-elements';
 
 
 const NavigateCard = () => {
@@ -40,7 +42,34 @@ const NavigateCard = () => {
           }}
 
         />
+        <NavFavorites />
       </View>
+
+      <View
+        style={tw`flex-row bg-white justify-evenly py-2 mt-auto border-t border-gray-100 mb-10`}
+      >
+        <TouchableOpacity 
+          style={tw`flex flex-row bg-black w-24 px-4 py-3 rounded-full justify-between`}
+          onPress={() => navigation.navigate("RideOptionsCard")}
+          >
+          <Icon name="car" type="font-awesome" color="white" size={16} />
+            <Text
+              style={tw`text-white text-center`}
+            >
+              Rides
+            </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity style={tw`flex flex-row w-24 px-4 py-3 rounded-full`}>
+          <Icon name="fast-food-outline" type="ionicon" color="black" size={16} />
+            <Text
+              style={tw`text-center`}
+            >
+              Eats
+            </Text>
+        </TouchableOpacity>
+      </View>
+
     </SafeAreaView>
   )
 }


### PR DESCRIPTION
Added two Icons 'Rides' and 'eats' from react-native-elements. Added them to the bottom of the component NavigateCard inside a TouchableOpacity. onPress it navigates to the RideOptionsScreen which I'll start building out now.